### PR TITLE
Decouple and add less tracing support.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var Bundle = require('./src/bundle');
 var EventEmitter = require('events').EventEmitter;
 var File = require('./src/file');
 var Fs = require('./src/fs');
-var Matcher = require('./src/matcher/all');
+var matcher = require('./src/matcher/all');
 var Tracer = require('./src/tracer');
 var Transformer = require('./src/transformer');
 var Watcher = require('./src/watcher');
@@ -12,8 +12,9 @@ var ubercod = require('ubercod');
 var dependencies = {
   $Bundle: Bundle,
   Events: EventEmitter,
+  $File: File,
   Fs: Fs,
-  Matcher: Matcher,
+  matcher: matcher,
   Tracer: Tracer,
   Transformer: Transformer,
   Watcher: Watcher

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "minimatch": "^2.0.1",
     "npm": "^2.7.0",
     "through": "^2.3.6",
-    "ubercod": "^0.1.0",
+    "ubercod": "0.1.1",
     "vinyl-transform": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "tmp": "0.0.25"
   },
   "dependencies": {
+    "babel": "*",
     "crypto": "0.0.3",
     "extend": "^2.0.0",
     "glob": "^4.4.1",

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -14,13 +14,13 @@ function filesToPaths (files) {
   });
 }
 
-function Bundle ($events, $fs, $tracer, $watcher, paths, options) {
+function Bundle ($events, $file, $tracer, $watcher, paths, options) {
   this._options = extend({
     common: false,
     joiner: '\n\n'
   }, options);
   this._events = $events;
-  this._fs = $fs;
+  this._file = $file;
   this._tracer = $tracer;
   this._watcher = $watcher;
   this.files = glob(paths);
@@ -121,12 +121,12 @@ Bundle.prototype = {
     });
 
     return traced.map(function (file) {
-      return that._fs.file(file).post;
+      return that._file(file).post;
     }).join(this._options.joiner);
   },
 
   compileOne: function (file) {
-    file = this._fs.file(file);
+    file = this._file(file);
     return this.all.indexOf(file.path) === -1 ? '' : file.post;
   },
 

--- a/src/file.js
+++ b/src/file.js
@@ -40,10 +40,6 @@ File.prototype = {
     }));
   },
 
-  cached: function () {
-    return cache[this.path];
-  },
-
   expire: function () {
     delete cache[this.path];
     delete this._code;

--- a/src/file.js
+++ b/src/file.js
@@ -9,7 +9,6 @@ function File ($matcher, $transformer, file) {
   }
 
   cache[file] = this;
-
   this._matcher = $matcher;
   this._transformer = $transformer;
   this._file = file;
@@ -48,7 +47,6 @@ File.prototype = {
   expire: function () {
     delete cache[this.path];
     delete this._code;
-    delete this._dependencies;
     delete this._imports;
     delete this._post;
     delete this._pre;

--- a/src/fs.js
+++ b/src/fs.js
@@ -8,9 +8,12 @@ function Fs () {
 }
 
 Fs.prototype = {
-  ext: function (file, ext, exts) {
-    exts = exts || [ext];
-    return exts.indexOf((path.extname(file) || '.').split('.')[1]) === -1 ? file + '.' + ext : file;
+  ext: function (file, defaultExt, validExts) {
+    var fileExt = (path.extname(file) || '.').split('.')[1];
+    validExts = validExts || [defaultExt];
+    return validExts.indexOf(fileExt) === -1 ?
+      file + '.' + defaultExt :
+      file;
   },
 
   map: function (map, path) {

--- a/src/matcher/all.js
+++ b/src/matcher/all.js
@@ -1,12 +1,14 @@
 'use strict';
 
-var CommonJs = require('./commonjs');
-var Compound = require('./compound');
-var Es6 = require('./es6');
+var commonJs = require('./commonjs');
+var compound = require('./compound');
+var es6 = require('./es6');
+var less = require('./less');
 
-module.exports = function () {
-  return new Compound([
-    new CommonJs(),
-    new Es6()
+module.exports = function ($fs) {
+  return compound($fs, [
+    commonJs,
+    es6,
+    less
   ]);
 };

--- a/src/matcher/commonjs.js
+++ b/src/matcher/commonjs.js
@@ -2,13 +2,13 @@
 
 var regexToArray = require('../util/regex-to-array');
 
-function Matcher() {}
-Matcher.prototype = {
-  match: function (code) {
+module.exports = function ($fs) {
+  return function (file, code) {
     return regexToArray(/require\([\'"]([^\'"]+)[\'"]\)/g, code).map(function (imp) {
-      return imp[1];
+      return {
+        path: $fs.ext($fs.resolve(imp[1], file), 'js', ['js', 'json']),
+        value: imp[1]
+      };
     });
-  }
+  };
 };
-
-module.exports = Matcher;

--- a/src/matcher/compound.js
+++ b/src/matcher/compound.js
@@ -6,12 +6,8 @@ module.exports = function ($fs, matchers) {
   });
 
   return function (file, code) {
-    var matches = [];
-
-    matchers.forEach(function (matcher) {
-      matches = matches.concat(matcher(file, code));
-    });
-
-    return matches;
+    return matchers.reduce(function (arr, matcher) {
+      return arr.concat(matcher(file, code));
+    }, []);
   };
 };

--- a/src/matcher/compound.js
+++ b/src/matcher/compound.js
@@ -1,19 +1,17 @@
 'use strict';
 
-function Matcher (matchers) {
-  this._matchers = matchers;
-}
+module.exports = function ($fs, matchers) {
+  matchers = matchers.map(function (matcher) {
+    return matcher($fs);
+  });
 
-Matcher.prototype = {
-  match: function (code) {
+  return function (file, code) {
     var matches = [];
 
-    this._matchers.forEach(function (matcher) {
-      matches = matches.concat(matcher.match(code));
+    matchers.forEach(function (matcher) {
+      matches = matches.concat(matcher(file, code));
     });
 
     return matches;
-  }
+  };
 };
-
-module.exports = Matcher;

--- a/src/matcher/es6.js
+++ b/src/matcher/es6.js
@@ -2,13 +2,13 @@
 
 var regexToArray = require('../util/regex-to-array');
 
-function Matcher() {}
-Matcher.prototype = {
-  match: function (code) {
+module.exports = function ($fs) {
+  return function (file, code) {
     return regexToArray(/^\s*import[^'"]*['"]([^'"]+)['"];?/gm, code).map(function (imp) {
-      return imp[1];
+      return {
+        path: $fs.ext($fs.resolve(imp[1], file), 'js', ['js', 'json']),
+        value: imp[1]
+      };
     });
-  }
+  };
 };
-
-module.exports = Matcher;

--- a/src/matcher/less.js
+++ b/src/matcher/less.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var regexToArray = require('../util/regex-to-array');
+
+module.exports = function ($fs) {
+  return function (file, code) {
+    return regexToArray(/^\s*@import\s*([^'"\s]*)\s*['"]([^'"]+)['"];?/gm, code).map(function (imp) {
+      return {
+        path: $fs.ext($fs.resolve(imp[2], file), 'less', ['css', 'less']),
+        type: imp[1],
+        value: imp[2]
+      };
+    });
+  };
+};

--- a/src/transform/globalize.js
+++ b/src/transform/globalize.js
@@ -35,7 +35,7 @@ function makePathRelative (file) {
 function defineDependencies (imports) {
   var code = '';
   var keyVals = imports.map(function (imp) {
-    return '"' + imp + '": ' + generateModuleName(imp.path);
+    return '"' + imp.value + '": ' + generateModuleName(imp.path);
   });
 
   keyVals.unshift('"exports": exports');

--- a/src/transform/globalize.js
+++ b/src/transform/globalize.js
@@ -43,7 +43,7 @@ module.exports = function () {
     }
 
     info.imports.forEach(function (imp, index) {
-      data = data.replace('require("' + imp + '")', generateModuleName(info.dependencies[index]));
+      data = data.replace('require("' + imp.value + '")', generateModuleName(imp.path));
     });
 
     data = data.replace(regexUseStrict, '');

--- a/src/transform/globalize.js
+++ b/src/transform/globalize.js
@@ -32,10 +32,10 @@ function makePathRelative (file) {
   return path.relative(process.cwd(), file);
 }
 
-function defineDependencies (imports, dependencies) {
+function defineDependencies (imports) {
   var code = '';
-  var keyVals = imports.map(function (imp, idx) {
-    return '"' + imp + '": ' + generateModuleName(dependencies[idx]);
+  var keyVals = imports.map(function (imp) {
+    return '"' + imp + '": ' + generateModuleName(imp.path);
   });
 
   keyVals.unshift('"exports": exports');
@@ -83,7 +83,7 @@ module.exports = function () {
     data = data.replace(regexUseStrict, '');
 
     // Replace all requires with references to dependency globals.
-    info.imports.forEach(function (imp, index) {
+    info.imports.forEach(function (imp) {
       data = data.replace('require("' + imp.value + '")', generateModuleName(imp.path));
     });
 
@@ -93,7 +93,7 @@ module.exports = function () {
 
     // We only need to generate the AMD -> CommonJS shim if it's used.
     if (isAmd) {
-      shims.push('var defineDependencies = ' + defineDependencies(info.imports, info.dependencies) + ';');
+      shims.push('var defineDependencies = ' + defineDependencies(info.imports) + ';');
       shims.push('var define = ' + defineReplacement + ';');
       shims.push('define.amd = true;');
     }

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -6,9 +6,9 @@ var gulpWatch = require('gulp-watch');
 var streams = {};
 var watched = {};
 
-function Watcher ($events, $fs, $tracer) {
+function Watcher ($events, $file, $tracer) {
   this._events = $events;
-  this._fs = $fs;
+  this._file = $file;
   this._tracer = $tracer;
 }
 
@@ -16,7 +16,7 @@ Watcher.prototype = {
   watch: function (bundle, callback) {
     var that = this;
     var watcher = gulpWatch(bundle.files, function (file) {
-      that._fs.file(file.path).clean();
+      that._file(file.path).expire();
 
       if (watched[file.path]) {
         return;
@@ -36,7 +36,7 @@ Watcher.prototype = {
 
           // If we don't uncache it then the file won't change and no new files
           // will be picked up.
-          that._fs.file(bundleFile).clean();
+          that._file(bundleFile).expire();
 
           // We actually have to write the main file to trigger a change.
           bundle.destinations(bundleFile).forEach(function (mainFile) {


### PR DESCRIPTION
Couple things in this PR:

- Add Less tracing support. The only solution for watching traced less files currently is https://www.npmjs.com/package/gulp-watch-less and it seems to be unmaintained as I've had PRs and issues open for awhile now with no response. Currently people are having to use my fork and I don't want to maintain it because it couples you to a version of Less. Since Galvatron is fairly abstract allowing for multiple matchers and transformers there's no reason we can't add Less support and use it for tracing / watching Less files. Transforming can still happen in other ways, unless we see fit to do that too.
- Decouple certain parts of the code. Especially FS and File. This was necessary to add Less support.