### PR TITLE
Replace single quote requires too.

### DIFF
--- a/src/transform/globalize.js
+++ b/src/transform/globalize.js
@@ -85,6 +85,7 @@ module.exports = function () {
     // Replace all requires with references to dependency globals.
     info.imports.forEach(function (imp) {
       data = data.replace('require("' + imp.value + '")', generateModuleName(imp.path));
+      data = data.replace("require('" + imp.value + "')", generateModuleName(imp.path));
     });
 
     // We assume CommonJS because that's what we're using to convert it.
@@ -102,7 +103,7 @@ module.exports = function () {
     data = shims.join('\n') + '\n\n' + data;
 
     // We assume this was set.
-    data = data + '\n\nreturn module.exports';
+    data = data + '\n\nreturn module.exports;';
 
     // Readability.
     data = indent(data);


### PR DESCRIPTION
Right now globalize just replaces require(""), not require(''). Babel 5.x now uses single quotes excessively, including in written requires.

Ideally this becomes more flexible (whitespace, etc.).