### PR TITLE
Expose lookup map for customization

### DIFF
--- a/src/fs.js
+++ b/src/fs.js
@@ -16,6 +16,11 @@ Fs.prototype = {
       file;
   },
 
+  lookups: {
+    'bower_components': 'bower.json',
+    'node_modules': 'package.json'
+  },
+
   map: function (map, path) {
     if (typeof map === 'object') {
       for (var a in map) {
@@ -38,17 +43,13 @@ Fs.prototype = {
     relativeTo = relativeTo ? path.dirname(relativeTo) : process.cwd();
     var dirs = relativeTo.split(path.sep);
     var foundFile;
-    var lookups = {
-      'bower_components': 'bower.json',
-      'node_modules': 'package.json'
-    };
 
     check:
     for (var a = 0; a < dirs.length; a++) {
-      for (var b in lookups) {
-        if (lookups.hasOwnProperty(b)) {
+      for (var b in this.lookups) {
+        if (this.lookups.hasOwnProperty(b)) {
           var checkDir = path.join(relativeTo, new Array(a).join('../'), b, mod);
-          var packageFile = path.join(checkDir, lookups[b]);
+          var packageFile = path.join(checkDir, this.lookups[b]);
 
           if (fs.existsSync(packageFile)) {
             var pkg = require(packageFile);


### PR DESCRIPTION
This exposes the lookups map on `galvatron.fs`, so that one can opt-out of either bower or npm lookups, or add others.