### PR TITLE
Use variations of node-detective to match imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
   "dependencies": {
     "babel": "*",
     "crypto": "0.0.3",
+    "debug": "^2.1.3",
+    "detective-cjs": "^1.0.2",
+    "detective-es6": "^1.1.0",
     "extend": "^2.0.0",
     "glob": "^4.4.1",
     "gulp-watch": "^4.1.1",

--- a/src/matcher/commonjs.js
+++ b/src/matcher/commonjs.js
@@ -1,15 +1,16 @@
 'use strict';
 
-var regexToArray = require('../util/regex-to-array');
+var detective = require('detective-cjs')
+var debug = require('debug');
+var log = debug('galvatron:matcher:commonjs')
 
 module.exports = function ($fs) {
   return function (file, code) {
-    // Replace comments just in case they have require blocks in them.
-    code = code.replace(/(\/\*([\s\S]*?)\*\/)|(\/\/(.*)$)/gm, '');
-    return regexToArray(/require\([\'"]([^\'"]+)[\'"]\)/g, code).map(function (imp) {
+    return detective(code).map(function (imp) {
+      log('resolving commonjs dependency', imp, 'from', file);
       return {
-        path: $fs.ext($fs.resolve(imp[1], file), 'js', ['js', 'json']),
-        value: imp[1]
+        path: $fs.ext($fs.resolve(imp, file), 'js', ['js', 'json']),
+        value: imp
       };
     });
   };

--- a/src/matcher/es6.js
+++ b/src/matcher/es6.js
@@ -1,13 +1,16 @@
 'use strict';
 
-var regexToArray = require('../util/regex-to-array');
+var detective = require('detective-es6');
+var debug = require('debug');
+var log = debug('galvatron:matcher:es6')
 
 module.exports = function ($fs) {
   return function (file, code) {
-    return regexToArray(/^\s*import[^'"]*['"]([^'"]+)['"];?/gm, code).map(function (imp) {
+    return detective(code).map(function (imp) {
+      log('resolving es6 dependency', imp, 'from', file);
       return {
-        path: $fs.ext($fs.resolve(imp[1], file), 'js', ['js', 'json']),
-        value: imp[1]
+        path: $fs.ext($fs.resolve(imp, file), 'js', ['js', 'json']),
+        value: imp
       };
     });
   };


### PR DESCRIPTION
This slows things down considerably (building asts instead of simple regexing) but makes detecting imports far more resilient. 

This also brings in the debug module for logging useful information when asked using the DEBUG env var.