### PR TITLE
Use index.js as well as pkg.main

### DIFF
--- a/src/fs.js
+++ b/src/fs.js
@@ -74,13 +74,11 @@ Fs.prototype = {
           } else if (fs.existsSync(packageFile)) {
             var pkg = require(packageFile);
 
-            if (pkg.main) {
-              // otherwise, return the module's main entry point.
-              var pkgMain = path.join(checkDir, pkg.main);
-              if (fs.existsSync(pkgMain)) {
-                foundFile = pkgMain;
-                break check;
-              }
+            // otherwise, return the module's main entry point.
+            var pkgMain = path.join(checkDir, pkg.main || 'index.js');
+            if (fs.existsSync(pkgMain)) {
+              foundFile = pkgMain;
+              break check;
             }
           }
         }


### PR DESCRIPTION
I'd like to be able to `import 'object-assign'`, which doesn't have a `pkg.main`, but it does use `index.js`.

They don't want to add `pkg.main`: https://github.com/sindresorhus/object-assign/pull/26