### PR TITLE
fix: throw readable error if import target is directory

### DIFF
--- a/src/trace/file.js
+++ b/src/trace/file.js
@@ -31,6 +31,11 @@ function trace (vinyl, opts) {
       throw new Error('cannot trace "' + vinyl.path + '" because "' + impPath + '" does not exist');
     }
 
+    var stat = fs.statSync(impPath);
+    if (stat.isDirectory()) {
+      throw new Error('cannot trace "' + vinyl.path + '" because "' + impPath + '" is a directory');
+    }
+
     return importCache[impPath] = {
       contents: new Buffer(fs.readFileSync(impPath)),
       path: impPath,

--- a/test/trace.js
+++ b/test/trace.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var expect = require('chai').expect;
 var fs = require('fs');
 var mocha = require('mocha');
 var trace = require('../src/trace');
@@ -21,5 +22,11 @@ mocha.describe('trace', function () {
     var stream = createReadStream('<jsx />');
     stream.on('end', done);
     stream.pipe(createWriteStream());
+  });
+
+  mocha.it('should error if dependency is a directory', function () {
+    expect(function() {
+      createReadStream('import "' + tmp.dirSync().name + '";');
+    }).to.throw(/is a directory/);
   });
 });


### PR DESCRIPTION
Currently when an import target is a directory, galvatron fails with this:
```
[04:43:58] 'distJs' errored after 786 ms
[04:43:58] Error: EISDIR: illegal operation on a directory, read
    at Error (native)
    at Object.fs.readSync (fs.js:651:19)
    at Object.fs.readFileSync (fs.js:472:24)
    at /usr/src/app/node_modules/galvatron/src/trace/file.js:35:31
    at Array.map (native)
    at trace (/usr/src/app/node_modules/galvatron/src/trace/file.js:23:49)
    at /usr/src/app/node_modules/galvatron/src/trace/file.js:46:24
    at Array.reduce (native)
    at trace (/usr/src/app/node_modules/galvatron/src/trace/file.js:41:24)
    at /usr/src/app/node_modules/galvatron/src/trace/file.js:46:24
```

after this fix there will be a readable error that allows for a fix:
```
[05:02:24] 'distJs' errored after 783 ms
[05:02:24] Error: cannot trace "/usr/src/app/src/js/aui/dropdown2.js" because "/usr/src/app/bower_components/skatejs-template-html" is a directory
    at /usr/src/app/node_modules/galvatron/src/trace/file.js:36:13
    at Array.map (native)
    at trace (/usr/src/app/node_modules/galvatron/src/trace/file.js:23:49)
    at /usr/src/app/node_modules/galvatron/src/trace/file.js:51:24
    at Array.reduce (native)
    at trace (/usr/src/app/node_modules/galvatron/src/trace/file.js:46:24)
    at /usr/src/app/node_modules/galvatron/src/trace/file.js:51:24
    at Array.reduce (native)
    at trace (/usr/src/app/node_modules/galvatron/src/trace/file.js:46:24)
    at module.exports (/usr/src/app/node_modules/galvatron/src/trace/file.js:58:10)
```